### PR TITLE
Link libamd_comgr on the COMGR path

### DIFF
--- a/api/opencl/amdocl/CMakeLists.txt
+++ b/api/opencl/amdocl/CMakeLists.txt
@@ -78,7 +78,7 @@ add_library(amdocl64 SHARED
   ${ADDITIONAL_LIBRARIES}
 )
 if(${USE_COMGR_LIBRARY} MATCHES "yes")
-  target_link_libraries(amdocl64 oclelf pthread dl ${ROCT_LIBRARIES} ${ROCR_LIBRARIES})
+  target_link_libraries(amdocl64 $<TARGET_OBJECTS:amd_comgr> oclelf pthread dl ${ROCT_LIBRARIES} ${ROCR_LIBRARIES})
 else()
   target_link_libraries(amdocl64 opencl_driver oclelf pthread dl ${ROCT_LIBRARIES} ${ROCR_LIBRARIES})
 endif()


### PR DESCRIPTION
This library is required when building with comgr. Not linking it as done in this PR can be worked around by having it available on the runtime linker's search path (i.e. LD_LIBRARY_PATH), but linking it as done here fixes an error where no OpenCL devices are found at runtime.