### PR TITLE
[debian] Change directory path of ld.so.conf

### DIFF
--- a/DEB/postinst
+++ b/DEB/postinst
@@ -3,7 +3,7 @@
 set -e
 
 do_ldconfig() {
-  echo /opt/rocm/opencl/lib/x86_64 > /etc/ld.so.conf.d/x86_64-rocm-opencl.conf && ldconfig
+  echo /opt/rocm/opencl/lib/ > /etc/ld.so.conf.d/x86_64-rocm-opencl.conf && ldconfig
   mkdir -p /etc/OpenCL/vendors && (echo libamdocl64.so > /etc/OpenCL/vendors/amdocl64.icd)
 }
 


### PR DESCRIPTION
ldconfig doesn't seems to like the path ended in x86_64, it
produces the following:

/opt/rocm-3.3.0/opencl/lib/x86_64: (hwcap: 0x0000000000000002)

and libraries aren't listed in the ld.cache. Removing the suffix allows
the linker to properly cache the cl libraries. Also it maintains
consistency with other ld.so.conf files of the ROCm project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/radeonopencompute/rocm-opencl-runtime/109)
<!-- Reviewable:end -->
