### PR TITLE
Install amdocl64.icd where ICD loader expects it

### DIFF
--- a/api/opencl/amdocl/CMakeLists.txt
+++ b/api/opencl/amdocl/CMakeLists.txt
@@ -85,4 +85,4 @@ else()
 endif()
 
 file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/amdocl64.icd" CONTENT "$<TARGET_FILE_NAME:amdocl64>")
-install(FILES "${CMAKE_BINARY_DIR}/amdocl64.icd" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/OpenCL/vendors/")
+install(FILES "${CMAKE_BINARY_DIR}/amdocl64.icd" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/OpenCL/vendors/")

--- a/api/opencl/amdocl/CMakeLists.txt
+++ b/api/opencl/amdocl/CMakeLists.txt
@@ -83,3 +83,6 @@ if(${USE_COMGR_LIBRARY} MATCHES "yes")
 else()
   target_link_libraries(amdocl64 opencl_driver oclelf pthread dl ${ROCT_LIBRARIES} ${ROCR_LIBRARIES})
 endif()
+
+file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/amdocl64.icd" CONTENT "$<TARGET_FILE_NAME:amdocl64>")
+install(FILES "${CMAKE_BINARY_DIR}/amdocl64.icd" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/OpenCL/vendors/")


### PR DESCRIPTION
ICD loaders expect the ICD configuration file to be exported to `/etc/OpenCL/vendors`, but currently the install process does not do that and require packagers to do it manually. This fixes the issue.

Thanks to the guys packaging for Gentoo for the fix.