### PR TITLE
Use BUILD_TESTS to control OpenCL tests

### DIFF
--- a/khronos/icd/CMakeLists.txt
+++ b/khronos/icd/CMakeLists.txt
@@ -128,7 +128,7 @@ target_include_directories (OpenCL PRIVATE ${CMAKE_CURRENT_BINARY_DIR} loader)
 target_link_libraries (OpenCL ${CMAKE_DL_LIBS})
 
 include (CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTS)
     add_subdirectory (test)
 endif()
 


### PR DESCRIPTION
It's unintuitive that you need to set both `BUILD_TESTS=OFF` and `BUILD_TESTING=OFF` to disable building *all* tests. This changes the OpenCL tests to instead just check `BUILD_TESTS`.